### PR TITLE
Homer-571/Red-header-menu-items-color

### DIFF
--- a/src/sass/components/_red-header.scss
+++ b/src/sass/components/_red-header.scss
@@ -45,7 +45,7 @@
 
   .header-nav {
     a,
-    button {
+    span {
       color: $colors-white;
     }
 


### PR DESCRIPTION
fixing css to keep red header showing white menu links after changing element from button to span