### PR TITLE
MAHOME-1141: Fix Broken Site Meta Data

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -31,31 +31,36 @@ const SEO = ({ title, description, image, article, isExternalImage }) => {
     image: ogImagePath,
     url: `${siteUrl}${pathname.slice(1)}`,
   };
+
+  return (
+    <>
+      <title>{seo.title}</title>
+      <meta name='description' content={seo.description} />
+      <meta name='image' content={seo.image} />
+      {seo.url && <meta property='og:url' content={seo.url} />}
+      {(article ? true : null) && <meta property='og:type' content='article' />}
+      {seo.title && <meta property='og:title' content={seo.title} />}
+      {seo.description && (
+        <meta property='og:description' content={seo.description} />
+      )}
+      {seo.image && <meta property='og:image' content={seo.image} />}
+      <meta name='twitter:card' content='summary_large_image' />
+      {twitterUsername && (
+        <meta name='twitter:creator' content={twitterUsername} />
+      )}
+      {seo.title && <meta name='twitter:title' content={seo.title} />}
+      {seo.description && (
+        <meta name='twitter:description' content={seo.description} />
+      )}
+      {seo.image && <meta name='twitter:image' content={seo.image} />}
+    </>
+  )
 };
+
 export default SEO;
 
 export const Head = () => (
-  <>
-    <title>{seo.title}</title>
-    <meta name='description' content={seo.description} />
-    <meta name='image' content={seo.image} />
-    {seo.url && <meta property='og:url' content={seo.url} />}
-    {(article ? true : null) && <meta property='og:type' content='article' />}
-    {seo.title && <meta property='og:title' content={seo.title} />}
-    {seo.description && (
-      <meta property='og:description' content={seo.description} />
-    )}
-    {seo.image && <meta property='og:image' content={seo.image} />}
-    <meta name='twitter:card' content='summary_large_image' />
-    {twitterUsername && (
-      <meta name='twitter:creator' content={twitterUsername} />
-    )}
-    {seo.title && <meta name='twitter:title' content={seo.title} />}
-    {seo.description && (
-      <meta name='twitter:description' content={seo.description} />
-    )}
-    {seo.image && <meta name='twitter:image' content={seo.image} />}
-  </>
+  <SEO />
 )
 
 SEO.propTypes = {


### PR DESCRIPTION
## What's Changed
- Fixed broken site meta data.

## Testing Locally
1. Run `yarn install`.
2. Confirm that .env file exists with correct credentials, then run `source .env`.
3. Run `npm run start`.