### PR TITLE
MAHOME-1147: Add Redirect for Press Release

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -183,6 +183,12 @@ exports.createPages = async ({ graphql, actions }) => {
     isPermanent: true,
     redirectInBrowser: true,
   })
+  createRedirect({
+    fromPath: "/press/2024-01-16-CivicActions-Announces-Impact-Report/reports.civicactions.com/impact",
+    toPath: "/press/2024-01-16-CivicActions-Announces-Impact-Report",
+    isPermanent: true,
+    redirectInBrowser: true,
+  })
 
   const caseStudies = result.data.caseStudies.edges;
   const CaseStudyTemplate = require.resolve('./src/templates/case-study.js');


### PR DESCRIPTION
## What's Changed
- Added redirect for `/press/2024-01-16-CivicActions-Announces-Impact-Report/reports.civicactions.com/impact` to point to `/press/2024-01-16-CivicActions-Announces-Impact-Report`.

## Testing Locally
1. Run `yarn install`.
2. Confirm that .env file exists with correct credentials, then run `source .env`.
3. Run `npm run start`.