### PR TITLE
fix(seo): add canonical URLs to strip query params

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -18,7 +18,7 @@ const SEO = ({ title, description, image, article }) => {
     title: (`${title || defaultTitle} | CivicActions`),
     description: description || defaultDescription,
     image: image ? image : defaultImage,
-    url: `${siteUrl}${pathname.slice(1)}`,
+    url: `${siteUrl.replace(/\/$/, '')}${pathname}`,
   };
 
   return (
@@ -41,6 +41,7 @@ const SEO = ({ title, description, image, article }) => {
         <meta name='twitter:description' content={seo.description} />
       )}
       {seo.image && <meta name='twitter:image' content={seo.image} />}
+      <link rel="canonical" href={seo.url} />
     </>
   )
 };


### PR DESCRIPTION
# 📝 One-line Summary

*A concise sentence describing what this PR does*

> **Issue:** [ITSM-1427](https://team.support.civicactions.com/servicedesk/customer/portal/4/ITSM-1427)

---

## 📖 Description

Srips url query params
---

## 🔧 Type of Change

*Indicate all that apply:*

* [x] 🆕 New feature (adds new functionality)
* [x] 🐛 Bug fix (non-breaking fix for a known issue)
* [x] 🔧 Configuration change


---

## ✅ Tasks to Complete

*Checklist of work being delivered in this PR:*

* [ ] Add/modify feature logic
* [ ] Write or update documentation
* [ ] Add or update tests
* [ ] Accessibility review
* [ ] Internal stakeholder check-in

---

## 👀 Review Checklist

*For reviewers to verify before approving:*

* [ ] Code follows project conventions
* [ ] Documentation is clear and complete
* [ ] Tests added or updated
* [ ] CHANGELOG updated (if applicable)
* [ ] No major accessibility regressions

---

## 🚀 Deployment Notes

*Are there migrations, feature flags, config updates, or coordination steps required?*



[ITSM-1427]: https://civicactions.atlassian.net/browse/ITSM-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ