### PR TITLE
fix: experiment to fix font weight issue in production.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Our home site is live at https://civicactions.com please check it out and bookma
 
 ## Related resources
 
-[The official react docs](https://reactjs.org/docs/getting-started.html)
+[The official react docs](https://react.dev/learn)
 
 [Intro to Gatsby](https://www.gatsbyjs.com/docs/tutorial/)
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -393,6 +393,7 @@ module.exports = {
             },
           ],
         },
+        formats: ['woff2'],
       },
     },
   ],


### PR DESCRIPTION
# 📝 One-line Summary

Restrict downloaded fonts to woff2 format in order to display the correct font-weight and font-family on production.

---

## 📖 Description

Light and normal font weights for Merriweather are being replaced by Nunito bold. According to this [issue](https://github.com/hupe1980/gatsby-plugin-webfonts/issues/76), possible changes to Google web fonts are clashing with gatsby-plugin-webfonts, resulting in the overriding of lower font weights. 

Although woff2 and woff fonts are being declared in the inline style tag only woff2 fonts are visible in the network tab. This PR restricts the formats to woff2, which fixes the issues in the below mentioned PR preview.

I uploaded a small change to the README to confirm that the issue appeared there before implementing the fix.

Changes:
- Update the README link for the React documentation to the newer react.dev site.
- Adjust gatsby-plugin-webfonts configuration to restrict downloaded font formats to woff2.


---

## 🔧 Type of Change

*Indicate all that apply:*

* [ ] 🆕 New feature (adds new functionality)
* [x] 🐛 Bug fix (non-breaking fix for a known issue)
* [ ] 🔧 Configuration change
* [ ] ♻️ Code refactor / performance improvement
* [ ] 📝 Documentation or non-code contribution

---

## ✅ Tasks to Complete

*Checklist of work being delivered in this PR:*

* [ ] Add/modify feature logic
* [ ] Write or update documentation
* [ ] Add or update tests
* [ ] Accessibility review
* [ ] Internal stakeholder check-in

---

## 👀 Review Checklist

*For reviewers to verify before approving:*

* [ ] Code follows project conventions
* [ ] Documentation is clear and complete
* [ ] Tests added or updated
* [ ] CHANGELOG updated (if applicable)
* [ ] No major accessibility regressions

---

## 🚀 Deployment Notes

*Are there migrations, feature flags, config updates, or coordination steps required?*

